### PR TITLE
Update call out tests with intl wrapper

### DIFF
--- a/public/query_assist/components/call_outs.test.tsx
+++ b/public/query_assist/components/call_outs.test.tsx
@@ -5,9 +5,14 @@
 
 import { render } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
+import { IntlProvider } from 'react-intl';
 import { QueryAssistCallOut } from './call_outs';
 
 type Props = ComponentProps<typeof QueryAssistCallOut>;
+
+const IntlWrapper = ({ children }: { children: unknown }) => (
+  <IntlProvider locale="en">{children}</IntlProvider>
+);
 
 const renderCallOut = (overrideProps: Partial<Props> = {}) => {
   const props: Props = Object.assign<Props, Partial<Props>>(
@@ -18,7 +23,9 @@ const renderCallOut = (overrideProps: Partial<Props> = {}) => {
     },
     overrideProps
   );
-  const component = render(<QueryAssistCallOut {...props} />);
+  const component = render(<QueryAssistCallOut {...props} />, {
+    wrapper: IntlWrapper,
+  });
   return { component, props: props as jest.MockedObjectDeep<Props> };
 };
 


### PR DESCRIPTION
Small change: clear some test warnings to keep test output clean, by providing an internationalization wrapper with the `en` locale.

Before:
<img width="1380" alt="image" src="https://github.com/kavilla/queryEnhancements/assets/31739405/b3df1b5d-821f-446c-bbd8-4ef7c608db38">

After:
<img width="765" alt="image" src="https://github.com/kavilla/queryEnhancements/assets/31739405/73a7c026-d80a-4c0d-92f3-78bc135993a4">
